### PR TITLE
Fix missing sanctum guard

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'sanctum' => [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+        ],
     ],
 
     /*


### PR DESCRIPTION
## Summary
- add sanctum guard to `config/auth.php`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851200401648327a598af1ae78e0b70